### PR TITLE
Avoid reloading tracks on horizontal swipe between tabs

### DIFF
--- a/android/app/src/main/java/com/votlin/android/ui/activity/TalksActivity.kt
+++ b/android/app/src/main/java/com/votlin/android/ui/activity/TalksActivity.kt
@@ -29,8 +29,10 @@ class TalksActivity : RootActivity<TalksView>(), TalksView {
 
     override val activityModule: Kodein.Module = Kodein.Module {
         bind<TalksPresenter>() with provider {
-            TalksPresenter(errorHandler = AndroidErrorHandler(),
-                    view = this@TalksActivity)
+            TalksPresenter(
+                errorHandler = AndroidErrorHandler(),
+                view = this@TalksActivity
+            )
         }
     }
 
@@ -44,7 +46,10 @@ class TalksActivity : RootActivity<TalksView>(), TalksView {
         viewPagerAdapter.addFragment(getString(R.string.business), TalksListFragment.newInstance(Track.BUSINESS))
         viewPagerAdapter.addFragment(getString(R.string.development), TalksListFragment.newInstance(Track.DEVELOPMENT))
         viewPagerAdapter.addFragment(getString(R.string.maker), TalksListFragment.newInstance(Track.MAKER))
-        viewPager.adapter = viewPagerAdapter
+        viewPager.apply {
+            adapter = viewPagerAdapter
+            offscreenPageLimit = 4
+        }
         tab.setupWithViewPager(viewPager)
     }
 

--- a/android/app/src/main/java/com/votlin/android/ui/activity/TalksActivity.kt
+++ b/android/app/src/main/java/com/votlin/android/ui/activity/TalksActivity.kt
@@ -48,7 +48,7 @@ class TalksActivity : RootActivity<TalksView>(), TalksView {
         viewPagerAdapter.addFragment(getString(R.string.maker), TalksListFragment.newInstance(Track.MAKER))
         viewPager.apply {
             adapter = viewPagerAdapter
-            offscreenPageLimit = 4
+            offscreenPageLimit = viewPagerAdapter.count
         }
         tab.setupWithViewPager(viewPager)
     }

--- a/android/app/src/main/java/com/votlin/android/ui/adapter/RootAdapter.kt
+++ b/android/app/src/main/java/com/votlin/android/ui/adapter/RootAdapter.kt
@@ -8,9 +8,10 @@ import android.view.ViewGroup
 /**
  * RootAdapter
  */
-abstract class RootAdapter<T>(protected val items: MutableList<T> = mutableListOf(),
-                              private val onItemClickListener: (T) -> Unit = {},
-                              private val onLongClickListener: (T) -> Unit = {}
+abstract class RootAdapter<T>(
+    protected val items: MutableList<T> = mutableListOf(),
+    private val onItemClickListener: (T) -> Unit = {},
+    private val onLongClickListener: (T) -> Unit = {}
 ) : RecyclerView.Adapter<RootAdapter.RootViewHolder<T>>() {
 
     abstract val itemLayoutId: Int
@@ -63,16 +64,19 @@ abstract class RootAdapter<T>(protected val items: MutableList<T> = mutableListO
         notifyDataSetChanged()
     }
 
-    fun replace(newItems: MutableList<T>) {
-        clear()
-        addAll(newItems)
+    fun replace(newItems: List<T>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
     }
 
     fun indexOf(item: T) = items.indexOf(item)
 
-    abstract class RootViewHolder<in T>(itemView: View,
-                                        var onItemClickListener: (Int) -> Unit = {},
-                                        var onLongClickListener: (Int) -> Unit = {}) : RecyclerView.ViewHolder(itemView) {
+    abstract class RootViewHolder<in T>(
+        itemView: View,
+        var onItemClickListener: (Int) -> Unit = {},
+        var onLongClickListener: (Int) -> Unit = {}
+    ) : RecyclerView.ViewHolder(itemView) {
 
         init {
             itemView.setOnClickListener { onItemClickListener(adapterPosition) }

--- a/android/app/src/main/java/com/votlin/android/ui/fragment/TalksListFragment.kt
+++ b/android/app/src/main/java/com/votlin/android/ui/fragment/TalksListFragment.kt
@@ -42,17 +42,16 @@ class TalksListFragment : RootFragment<TalksListView>(), TalksListView {
         bind<TalksListPresenter>() with provider {
             TalksListPresenter(
                 view = this@TalksListFragment,
-                errorHandler = AndroidErrorHandler(),
+                errorHandler = instance(),
                 executor = instance(),
                 repository = instance()
             )
         }
     }
 
-    private lateinit var talksAdapter: TalksAdapter
+    private val talksAdapter = TalksAdapter { presenter.onTalkClicked(it) }
 
     override fun initializeUI() {
-        talksAdapter = TalksAdapter { presenter.onTalkClicked(it) }
         talks.apply {
             layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
             adapter = talksAdapter
@@ -63,17 +62,13 @@ class TalksListFragment : RootFragment<TalksListView>(), TalksListView {
         // Nothing to do here
     }
 
-    override fun showProgress() {
-        progressView.showMe()
-    }
+    override fun showProgress() = progressView.showMe()
 
-    override fun hideProgress() {
-        progressView.hideMe()
-    }
+    override fun hideProgress() = progressView.hideMe()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        presenter.onViewCreated(getTrack())
+        presenter.viewLoaded(getTrack())
     }
 
     private fun getTrack(): Track {

--- a/android/app/src/main/java/com/votlin/android/ui/fragment/TalksListFragment.kt
+++ b/android/app/src/main/java/com/votlin/android/ui/fragment/TalksListFragment.kt
@@ -41,56 +41,52 @@ class TalksListFragment : RootFragment<TalksListView>(), TalksListView {
     override val fragmentModule: Kodein.Module = Kodein.Module {
         bind<TalksListPresenter>() with provider {
             TalksListPresenter(
-                    view = this@TalksListFragment,
-                    errorHandler = AndroidErrorHandler(),
-                    executor = instance(),
-                    repository = instance())
+                view = this@TalksListFragment,
+                errorHandler = AndroidErrorHandler(),
+                executor = instance(),
+                repository = instance()
+            )
         }
     }
 
-    private val adapter = TalksAdapter { presenter.onTalkClicked(it) }
+    private lateinit var talksAdapter: TalksAdapter
 
     override fun initializeUI() {
-        talks.layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
-        talks.adapter = adapter
+        talksAdapter = TalksAdapter { presenter.onTalkClicked(it) }
+        talks.apply {
+            layoutManager = LinearLayoutManager(activity, LinearLayoutManager.VERTICAL, false)
+            adapter = talksAdapter
+        }
     }
 
     override fun registerListeners() {
         // Nothing to do here
     }
 
-    override fun showProgress() = progressView.showMe()
+    override fun showProgress() {
+        progressView.showMe()
+    }
 
-    override fun hideProgress() = progressView.hideMe()
+    override fun hideProgress() {
+        progressView.hideMe()
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        if (userVisibleHint) {
-            presenter.onTrackChanged(getTrack())
-        }
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser && isResumed) {
-            presenter.onTrackChanged(getTrack())
-        }
+        presenter.onViewCreated(getTrack())
     }
 
     private fun getTrack(): Track {
         val bundle = arguments
         val track = bundle?.getString(TRACK)
 
-        try {
-            return Track.valueOf(track!!)
-        } catch (e: IllegalArgumentException) {
-            throw IllegalArgumentException("This fragment only can works if you pass the track")
-        }
+        track?.let {
+            return Track.valueOf(it)
+        } ?: throw IllegalArgumentException("This fragment only can works if you pass the track")
     }
 
     override fun showTalks(talks: List<Talk>) {
-        adapter.replace(talks.toMutableList())
+        talksAdapter.replace(talks)
     }
 
     override fun goToTalkScreen(id: Int) {

--- a/common/src/main/kotlin/com/votlin/client/presentation/TalksListPresenter.kt
+++ b/common/src/main/kotlin/com/votlin/client/presentation/TalksListPresenter.kt
@@ -10,11 +10,12 @@ import com.votlin.model.Track
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class TalksListPresenter(private val executor: Executor,
-                         private val repository: Repository,
-                         view: TalksListView,
-                         errorHandler: ErrorHandler) :
-        Presenter<TalksListView>(view = view, errorHandler = errorHandler) {
+class TalksListPresenter(
+    private val executor: Executor,
+    private val repository: Repository,
+    view: TalksListView,
+    errorHandler: ErrorHandler
+) : Presenter<TalksListView>(view = view, errorHandler = errorHandler) {
 
     override fun initialize() {
         // Nothing to do
@@ -24,15 +25,16 @@ class TalksListPresenter(private val executor: Executor,
         // Nothing to do yet
     }
 
-    fun onTrackChanged(track: Track) {
-        view.showProgress()
-
+    fun onViewCreated(track: Track) {
         getTalks(track)
     }
 
-    fun onTalkClicked(talk: Talk) = view.goToTalkScreen(talk.id)
+    fun onTalkClicked(talk: Talk) {
+        view.goToTalkScreen(talk.id)
+    }
 
     private fun getTalks(track: Track) {
+        view.showProgress()
         GlobalScope.launch(context = executor.main) {
             val talks = when (track) {
                 Track.ALL -> getAllTalks(repository)

--- a/common/src/main/kotlin/com/votlin/client/presentation/TalksListPresenter.kt
+++ b/common/src/main/kotlin/com/votlin/client/presentation/TalksListPresenter.kt
@@ -25,7 +25,7 @@ class TalksListPresenter(
         // Nothing to do yet
     }
 
-    fun onViewCreated(track: Track) {
+    fun viewLoaded(track: Track) {
         getTalks(track)
     }
 


### PR DESCRIPTION
Hi folks!! The android app was reloading the tracks info on every horizontal swipe between tabs. I have made some changes for loading this tracks only when every fragment is created. Hope you like it!